### PR TITLE
CSS Modules

### DIFF
--- a/packages/webpack-config-web/README.md
+++ b/packages/webpack-config-web/README.md
@@ -301,7 +301,7 @@ See [devServer.port](https://webpack.js.org/configuration/dev-server/#devserver-
 
 
 ---
-### `cssModules`: Boolean
+### `cssModules`: Boolean or String or Object
 
 The **CSS Modules** option makes classnames and identifiers globally unique at build time,
 and importing a stylesheet returns an object with the generated unique classnames.

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "5.0.0-alpha1",
+  "version": "4.12.0",
   "description": "Webpack 4 base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-web/src/getConfig.d.ts
+++ b/packages/webpack-config-web/src/getConfig.d.ts
@@ -271,7 +271,14 @@ type GetConfigOptions = {
 	 * @default true
 	 * @see [Modules](https://github.com/webpack-contrib/css-loader#modules) in the `css-loader` documentation
 	 */
-	cssModules?: boolean;
+	cssModules?: boolean | 'global' | 'local' | 'pure' | {
+		mode?: 'global' | 'local' | 'pure';
+		localIdentName?: string;
+		context?: string;
+		hashPrefix?: string;
+		getLocalIdent?: any;
+		[key: string]: any;
+	};
 
 	/**
 	 * Prepends arbitrary SCSS (or plain CSS) code to all `.css` and `.scss` files.

--- a/packages/webpack-config-web/src/getConfig.js
+++ b/packages/webpack-config-web/src/getConfig.js
@@ -105,7 +105,14 @@ module.exports = function getConfig({
 	strictEqual(isNaN(port), false, '"port" must not be NaN');
 	strictEqual(port > 0, true, '"port" should be a positive number');
 
-	strictEqual(typeof cssModules, "boolean", '"cssModules" should be a Boolean');
+	const okCssModules = (
+		(cssModules !== null) && (
+			(typeof cssModules === "boolean") ||
+			(typeof cssModules === "object") ||
+			(typeof cssModules === "string")
+		)
+	);
+	strictEqual(okCssModules, true, '"cssModules" should be a Boolean');
 	strictEqual(
 		typeof scss === "string" || typeof scss === "function" || typeof scss === "undefined",
 		true,

--- a/test/params-cssModules.spec.js
+++ b/test/params-cssModules.spec.js
@@ -31,14 +31,17 @@ function testFixture(title, cssModules, expectThrows) {
 describe("cssModules", () => {
 	testFixture("Valid: true", true, false);
 	testFixture("Valid: false", true, false);
-	testFixture('Invalid: ""', "", true);
-	testFixture('Invalid: "true"', "true", true);
-	testFixture('Invalid: "false"', "false", true);
+
+	// It only checks for the data type, not the value inside
+	testFixture("Valid: {}", {}, false);
+	testFixture('Valid: ""', "", false);
+	testFixture('Valid: "true"', "true", false);
+	testFixture('Valid: "false"', "false", false);
+
 	testFixture("Invalid: 123", 123, true);
 	testFixture("Invalid: 0", 0, true);
 	testFixture("Invalid: NaN", NaN, true);
 	testFixture("Invalid: -1", -1, true);
-	testFixture("Invalid: {}", {}, true);
 	testFixture("Invalid: null", null, true);
 	testFixture("Invalid: Symbol", Symbol("true"), true);
 });


### PR DESCRIPTION
Option `cssModules` now accepts String and Object values as well, not just Boolean (see #406).