### PR TITLE
Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "0.11.1",
     "node-sass": "4.14.1",
-    "postcss-loader": "3.0.0",
+    "postcss-loader": "4.0.1",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.1",
     "sass-loader": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "4.4.1",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "0.11.0",
+    "mini-css-extract-plugin": "0.11.1",
     "node-sass": "4.14.1",
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "6.1.0",
     "core-js": "3.6.5",
-    "css-loader": "4.2.2",
+    "css-loader": "4.3.0",
     "cssnano": "4.1.10",
     "file-loader": "6.1.0",
     "html-webpack-plugin": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postcss-loader": "4.0.1",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.1",
-    "sass-loader": "10.0.1",
+    "sass-loader": "10.0.2",
     "source-map-loader": "1.1.0",
     "style-loader": "1.2.1",
     "ts-loader": "8.0.3",

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-node",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Webpack 4 base config generator for bundling Node apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -23,7 +23,7 @@
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "6.1.0",
     "core-js": "3.6.5",
-    "css-loader": "4.2.2",
+    "css-loader": "4.3.0",
     "cssnano": "4.1.10",
     "file-loader": "6.1.0",
     "html-webpack-plugin": "4.4.1",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -31,7 +31,7 @@
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "0.11.1",
     "node-sass": "4.14.1",
-    "postcss-loader": "3.0.0",
+    "postcss-loader": "4.0.1",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.1",
     "sass-loader": "10.0.1",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -34,7 +34,7 @@
     "postcss-loader": "4.0.1",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.1",
-    "sass-loader": "10.0.1",
+    "sass-loader": "10.0.2",
     "source-map-loader": "1.1.0",
     "style-loader": "1.2.1",
     "ts-loader": "8.0.3",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -29,7 +29,7 @@
     "html-webpack-plugin": "4.4.1",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "0.11.0",
+    "mini-css-extract-plugin": "0.11.1",
     "node-sass": "4.14.1",
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.7.0",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Webpack 4 base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-web/src/getConfig.js
+++ b/packages/webpack-config-web/src/getConfig.js
@@ -341,8 +341,9 @@ module.exports = function getConfig({
 		{
 			loader: "postcss-loader",
 			options: {
-				ident: "postcss",
-				plugins: postcssPlugins
+				postcssOptions: {
+					plugins: postcssPlugins
+				}
 			}
 		}
 	];


### PR DESCRIPTION
Updated `css-loader`, `mini-css-extract-plugin`, `postcss-loader`, and `sass-loader`.

Some tests fail and the major update of `postcss-loader` is the most likely cause so far (usually it turns out to be small things like an option got renamed), especially as Dependabot hasn't yet created a PR for the postcss-loader update whereas the PR for the other 3 dependency updates pass tests just fine.