### PR TITLE
5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ts-loader": "8.0.4",
     "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.4.1",
-    "worker-loader": "3.0.3"
+    "worker-loader": "3.0.4"
   },
   "devDependencies": {
     "@types/node": "14.11.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "1.0.0",
     "node-sass": "4.14.1",
-    "postcss-loader": "4.0.3",
+    "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.1",
     "sass-loader": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "6.2.0",
+    "copy-webpack-plugin": "6.2.1",
     "core-js": "3.6.5",
     "css-loader": "4.3.0",
     "cssnano": "4.1.10",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "worker-loader": "3.0.4"
   },
   "devDependencies": {
-    "@types/node": "14.11.7",
+    "@types/node": "14.11.8",
     "@wildpeaks/eslint-config-commonjs": "10.7.0",
     "@wildpeaks/snapshot-dom": "2.0.0",
     "eslint": "7.10.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "source-map-loader": "1.1.1",
     "style-loader": "1.3.0",
     "ts-loader": "8.0.4",
-    "url-loader": "4.1.0",
+    "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.4.1",
     "worker-loader": "3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.2",
-    "sass-loader": "10.0.2",
+    "sass-loader": "10.0.3",
     "source-map-loader": "1.1.0",
     "style-loader": "1.3.0",
     "ts-loader": "8.0.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "1.0.0",
+    "mini-css-extract-plugin": "0.11.3",
     "node-sass": "4.14.1",
     "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.2",
     "sass-loader": "10.0.3",
-    "source-map-loader": "1.1.0",
+    "source-map-loader": "1.1.1",
     "style-loader": "1.3.0",
     "ts-loader": "8.0.4",
     "url-loader": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "core-js": "3.6.5",
     "css-loader": "4.3.0",
     "cssnano": "4.1.10",
-    "file-loader": "6.1.0",
+    "file-loader": "6.1.1",
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "0.11.3",
+    "mini-css-extract-plugin": "1.0.0",
     "node-sass": "4.14.1",
     "postcss-loader": "4.0.3",
     "postcss-preset-env": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "raw-loader": "4.0.2",
     "sass-loader": "10.0.3",
     "source-map-loader": "1.1.1",
-    "style-loader": "1.3.0",
+    "style-loader": "2.0.0",
     "ts-loader": "8.0.4",
     "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-sass": "4.14.1",
     "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",
-    "raw-loader": "4.0.1",
+    "raw-loader": "4.0.2",
     "sass-loader": "10.0.2",
     "source-map-loader": "1.1.0",
     "style-loader": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "14.11.8",
     "@wildpeaks/eslint-config-commonjs": "10.7.0",
     "@wildpeaks/snapshot-dom": "2.0.0",
-    "eslint": "7.10.0",
+    "eslint": "7.11.0",
     "express": "4.17.1",
     "fs-extra": "9.0.1",
     "mocha": "8.1.3",

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-configs/tree/master/packages/webpack-config-node",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "6.2.0",
+    "copy-webpack-plugin": "6.2.1",
     "source-map-loader": "1.1.0",
     "ts-loader": "8.0.4"
   },

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-node",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Webpack 4 base config generator for bundling Node apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "6.2.1",
-    "source-map-loader": "1.1.0",
+    "source-map-loader": "1.1.1",
     "ts-loader": "8.0.4"
   },
   "peerDependencies": {

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -35,7 +35,7 @@
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.2",
     "sass-loader": "10.0.3",
-    "source-map-loader": "1.1.0",
+    "source-map-loader": "1.1.1",
     "style-loader": "1.3.0",
     "ts-loader": "8.0.4",
     "url-loader": "4.1.0",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -29,7 +29,7 @@
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "1.0.0",
+    "mini-css-extract-plugin": "0.11.3",
     "node-sass": "4.14.1",
     "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "Webpack 4 base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -29,7 +29,7 @@
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "0.11.3",
+    "mini-css-extract-plugin": "1.0.0",
     "node-sass": "4.14.1",
     "postcss-loader": "4.0.3",
     "postcss-preset-env": "6.7.0",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -40,7 +40,7 @@
     "ts-loader": "8.0.4",
     "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.4.1",
-    "worker-loader": "3.0.3"
+    "worker-loader": "3.0.4"
   },
   "peerDependencies": {
     "typescript": "*",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -33,7 +33,7 @@
     "node-sass": "4.14.1",
     "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",
-    "raw-loader": "4.0.1",
+    "raw-loader": "4.0.2",
     "sass-loader": "10.0.2",
     "source-map-loader": "1.1.0",
     "style-loader": "1.3.0",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-configs/tree/master/packages/webpack-config-web",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "6.2.0",
+    "copy-webpack-plugin": "6.2.1",
     "core-js": "3.6.5",
     "css-loader": "4.3.0",
     "cssnano": "4.1.10",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -34,7 +34,7 @@
     "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.2",
-    "sass-loader": "10.0.2",
+    "sass-loader": "10.0.3",
     "source-map-loader": "1.1.0",
     "style-loader": "1.3.0",
     "ts-loader": "8.0.4",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -31,7 +31,7 @@
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "1.0.0",
     "node-sass": "4.14.1",
-    "postcss-loader": "4.0.3",
+    "postcss-loader": "4.0.4",
     "postcss-preset-env": "6.7.0",
     "raw-loader": "4.0.1",
     "sass-loader": "10.0.2",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -38,7 +38,7 @@
     "source-map-loader": "1.1.1",
     "style-loader": "1.3.0",
     "ts-loader": "8.0.4",
-    "url-loader": "4.1.0",
+    "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.4.1",
     "worker-loader": "3.0.3"
   },

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -36,7 +36,7 @@
     "raw-loader": "4.0.2",
     "sass-loader": "10.0.3",
     "source-map-loader": "1.1.1",
-    "style-loader": "1.3.0",
+    "style-loader": "2.0.0",
     "ts-loader": "8.0.4",
     "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.4.1",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -25,7 +25,7 @@
     "core-js": "3.6.5",
     "css-loader": "4.3.0",
     "cssnano": "4.1.10",
-    "file-loader": "6.1.0",
+    "file-loader": "6.1.1",
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",


### PR DESCRIPTION
Updated dependencies (`copy-webpack-plugin`, `file-loader`, `postcss-loader`, `raw-loader`, `sass-loader`, `source-map-loader`, `style-loader`, `url-loader`, `worker-loader`) and devDependencies.

`mini-css-extract-plugin` will be updated later because it breaks some tests at the moment.

`webpack` & `webpack-cli` will be updated much later, as part of the [Webpack 5](https://github.com/wildpeaks/package-webpack-configs/issues/371) issue.