### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "worker-loader": "3.0.6"
   },
   "devDependencies": {
-    "@types/node": "14.14.11",
+    "@types/node": "14.14.12",
     "@wildpeaks/eslint-config-commonjs": "10.7.0",
     "@wildpeaks/snapshot-dom": "2.0.0",
     "eslint": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sass-loader": "10.1.0",
     "source-map-loader": "1.1.3",
     "style-loader": "2.0.0",
-    "ts-loader": "8.0.11",
+    "ts-loader": "8.0.12",
     "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.5.2",
     "worker-loader": "3.0.6"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "1.3.2",
+    "mini-css-extract-plugin": "1.3.3",
     "node-sass": "5.0.0",
     "postcss-loader": "4.1.0",
     "postcss-preset-env": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "6.4.0",
+    "copy-webpack-plugin": "7.0.0",
     "core-js": "3.8.1",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "7.0.0",
+    "copy-webpack-plugin": "6.4.0",
     "core-js": "3.8.1",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -23,7 +23,7 @@
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "6.4.0",
     "source-map-loader": "1.1.3",
-    "ts-loader": "8.0.11"
+    "ts-loader": "8.0.12"
   },
   "peerDependencies": {
     "typescript": "*",

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-node",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "Webpack 4 base config generator for bundling Node apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-configs/tree/master/packages/webpack-config-node",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "6.4.0",
+    "copy-webpack-plugin": "7.0.0",
     "source-map-loader": "1.1.3",
     "ts-loader": "8.0.12"
   },

--- a/packages/webpack-config-node/package.json
+++ b/packages/webpack-config-node/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-configs/tree/master/packages/webpack-config-node",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "7.0.0",
+    "copy-webpack-plugin": "6.4.0",
     "source-map-loader": "1.1.3",
     "ts-loader": "8.0.12"
   },

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wildpeaks/webpack-config-web",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "Webpack 4 base config generator for Web apps",
   "author": "Cecile Muller",
   "license": "MIT",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-configs/tree/master/packages/webpack-config-web",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "7.0.0",
+    "copy-webpack-plugin": "6.4.0",
     "core-js": "3.8.1",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/wildpeaks/package-webpack-configs/tree/master/packages/webpack-config-web",
   "dependencies": {
     "clean-webpack-plugin": "3.0.0",
-    "copy-webpack-plugin": "6.4.0",
+    "copy-webpack-plugin": "7.0.0",
     "core-js": "3.8.1",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -37,7 +37,7 @@
     "sass-loader": "10.1.0",
     "source-map-loader": "1.1.3",
     "style-loader": "2.0.0",
-    "ts-loader": "8.0.11",
+    "ts-loader": "8.0.12",
     "url-loader": "4.1.1",
     "webpack-subresource-integrity": "1.5.2",
     "worker-loader": "3.0.6"

--- a/packages/webpack-config-web/package.json
+++ b/packages/webpack-config-web/package.json
@@ -29,7 +29,7 @@
     "html-webpack-plugin": "4.5.0",
     "html-webpack-tags-plugin": "2.0.17",
     "loader-utils": "2.0.0",
-    "mini-css-extract-plugin": "1.3.2",
+    "mini-css-extract-plugin": "1.3.3",
     "node-sass": "5.0.0",
     "postcss-loader": "4.1.0",
     "postcss-preset-env": "6.7.0",


### PR DESCRIPTION
Updated `@types/node`, `mini-css-extract-plugin`, and `ts-loader`.

`copy-webpack-plugin` cannot be updated yet because it requires Webpack 5.

